### PR TITLE
Actually run the tests against the original data and dump outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 
 # macOS
 .DS_Store
+
+/out

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ARC-AGI-2"]
+	path = ARC-AGI-2
+	url = https://github.com/arcprize/ARC-AGI-2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 A dataset containing 120 ARC-AGI-2 evaluation tasks with solvers written in **CompDSL**—a purely functional, simply-typed DSL for grid transformation programs. Each solver is guaranteed to terminate with polynomial complexity bounds and maintains equational reasoning properties.
 
+## How to run solvers and check output correctness
+
+```
+./test.py
+```
+
+This also produces `out/*.json` files containing the output, which can be plotted for visual inspection with:
+
+```
+virtualenv -p python3 .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+./plot.py out/0934a4d8.json
+```
+
 ## What is CompDSL?
 
 CompDSL is a purely functional, simply-typed DSL for grid programs embedded in disciplined Python. Every solver is guaranteed to terminate in O(n^d) time with no mutation, recursion, or unbounded loops.

--- a/plot.py
+++ b/plot.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+'''
+Adapted from https://www.kaggle.com/code/allegich/arc-agi-2025-visualization-all-1000-120-tasks
+'''
+
+import argparse
+import json
+from os import path
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from matplotlib import colors
+
+# 0:black, 1:blue, 2:red, 3:green, 4:yellow, # 5:gray, 6:magenta, 7:orange, 8:sky, 9:brown
+cmap = colors.ListedColormap([
+    '#000000', '#0074D9', '#FF4136', '#2ECC40', '#FFDC00',
+    '#AAAAAA', '#F012BE', '#FF851B', '#7FDBFF', '#870C25'
+])
+norm = colors.Normalize(vmin=0, vmax=9)
+
+def plot_task(
+    json_path: str,
+    task,
+    save: bool,
+    size=2.5,
+    w1=0.9
+):
+    num_train = len(task['train'])
+    num_test = len(task['test'])
+    wn = num_train + num_test
+    has_actual = 'actual' in task['train'][0]
+    has_actual = any('actual' in entry for entry in task['train'] + task['test'])
+    fig, axs = plt.subplots(
+        3 if has_actual else 2,
+        wn,
+        figsize=(size*wn,2*size)
+    )
+    for j in range(num_train):     
+        plot_one(axs[0, j], j, task, 'train', 'input',  w=w1)
+        plot_one(axs[1, j], j, task, 'train', 'output', w=w1)
+        if has_actual:
+            plot_one(axs[2, j], j, task, 'train', 'actual', w=w1)
+    for k in range(num_test):
+        plot_one(axs[0, j+k+1], k, task, 'test', 'input', w=w1)
+        plot_one(axs[1, j+k+1], k, task, 'test', 'output', w=w1)
+        if has_actual:
+            plot_one(axs[2, j+k+1], k, task, 'test', 'actual', w=w1)
+    axs[1, j+1].set_xticklabels([])
+    axs[1, j+1].set_yticklabels([])
+    axs[1, j+1] = plt.figure(1).add_subplot(111)
+    axs[1, j+1].set_xlim([0, wn])
+    
+    # Separators
+    colorSeparator = 'white'
+    for m in range(1, wn):
+        axs[1, j+1].plot([m,m],[0,1],'--', linewidth=1, color = colorSeparator)
+    axs[1, j+1].plot([num_train,num_train],[0,1],'-', linewidth=3, color = colorSeparator)
+    axs[1, j+1].axis("off")
+
+    # Frame and background
+    fig.patch.set_linewidth(5)
+    fig.patch.set_edgecolor('black')
+    fig.patch.set_facecolor('#444444')
+    fig.tight_layout()
+    if save:
+        plt.savefig(path.splitext(json_path)[0] + '.png')
+    else:
+        fig.canvas.manager.set_window_title(Path(json_path).stem)
+        plt.show()  
+    plt.close()
+   
+def plot_one(
+    ax,
+    i: int,
+    task,
+    train_or_test: str,
+    input_or_output: str,
+    solution=None,
+    w=0.8
+):
+    fs = 12
+    task[train_or_test][i]
+    matrix = task[train_or_test][i].get(input_or_output, None)
+    ax.set_title(
+        f'{train_or_test} {input_or_output} {i}' + (' (error)' if matrix is None else ''),
+        fontsize=fs,
+        color='#dddddd'
+    )
+    if matrix is not None:
+        ax.imshow(matrix, cmap=cmap, norm=norm)
+        plt.setp(plt.gcf().get_axes(), xticklabels=[], yticklabels=[])
+        ax.set_xticks([x-0.5 for x in range(1 + len(matrix[0]))])
+        ax.set_yticks([x-0.5 for x in range(1 + len(matrix))])
+        ax.grid(visible= True, which = 'both', color = '#666666', linewidth = w)
+        ax.tick_params(axis='both', color='none', length=0)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--save', default=False, action='store_true', help='Save PNG render instead of popup window')
+    parser.add_argument('-i', '--id', default=False, action='store_true', help='Provide input by hash ID. If given, json-path can be omitted')
+    parser.add_argument('json-path', nargs='+')
+    args = parser.parse_args()
+    json_paths = getattr(args, 'json-path')
+    if args.id:
+        for i, json_path in enumerate(json_paths):
+            json_paths[i] = path.join('ARC-AGI', 'data', 'training', json_path) + '.json'
+    for json_path in json_paths:
+        with open(json_path) as f:
+            task = json.load(f)
+        if len(json_paths) > 1:
+            print(json_path)
+        plot_task(json_path, task, args.save)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib==3.10.7

--- a/test.py
+++ b/test.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from importlib import util
+from pathlib import Path
+from typing import Callable, Iterable, List, Sequence
+
+Grid = List[List[int]]
+Solver = Callable[[Grid], Sequence[Sequence[int]]]
+
+
+@dataclass
+class ExampleFailure:
+    split: str
+    index: int
+    reason: str
+
+
+@dataclass
+class TaskResult:
+    task_id: str
+    total_examples: int
+    failures: List[ExampleFailure]
+    predicted: dict
+    load_error: str | None = None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run task solutions against the ARC-AGI-2 ground truth data."
+    )
+    parser.add_argument(
+        "--data-root",
+        default="ARC-AGI-2/data/evaluation",
+        help="Directory containing task JSON files (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--tasks",
+        nargs="*",
+        help="Optional list of task ids to run. Defaults to every directory under tasks/.",
+    )
+    parser.add_argument(
+        "--skip-train", action="store_true", help="Skip checking training examples."
+    )
+    parser.add_argument(
+        "--skip-test", action="store_true", help="Skip checking test examples."
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only print failing tasks and the final summary.",
+    )
+    return parser.parse_args()
+
+
+def discover_tasks(root: Path, selected: set[str] | None) -> tuple[list[tuple[str, Path]], set[str]]:
+    tasks: list[tuple[str, Path]] = []
+    seen: set[str] = set()
+    for bundle in sorted(p for p in root.iterdir() if p.is_dir()):
+        task_id = bundle.name
+        seen.add(task_id)
+        if selected and task_id not in selected:
+            continue
+        solution_path = bundle / "solution.py"
+        if solution_path.exists():
+            tasks.append((task_id, solution_path))
+    missing = set() if not selected else selected - seen
+    return tasks, missing
+
+
+def load_solver(task_id: str, path: Path) -> Solver:
+    module_name = f"tasks.{task_id}.solution"
+    spec = util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load module for {task_id} from {path}")
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    func_name = f"solve_{task_id}"
+    solver = getattr(module, func_name, None) or getattr(module, "p", None)
+    if solver is None:
+        raise AttributeError(f"{path} does not expose {func_name} or p")
+    return solver
+
+
+def load_task_json(data_root: Path, task_id: str) -> dict:
+    json_path = data_root / f"{task_id}.json"
+    if not json_path.exists():
+        raise FileNotFoundError(f"Missing task data: {json_path}")
+    with json_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def copy_grid(grid: Sequence[Sequence[int]]) -> Grid:
+    return [list(row) for row in grid]
+
+
+def compare_grids(expected: Sequence[Sequence[int]], actual: Sequence[Sequence[int]]) -> str | None:
+    if len(expected) != len(actual):
+        return f"height mismatch (expected {len(expected)}, got {len(actual)})"
+    for r, (exp_row, act_row) in enumerate(zip(expected, actual)):
+        if len(exp_row) != len(act_row):
+            return f"row {r} width mismatch (expected {len(exp_row)}, got {len(act_row)})"
+        for c, (exp, act) in enumerate(zip(exp_row, act_row)):
+            if exp != act:
+                return f"cell ({r},{c}) expected {exp}, got {act}"
+    return None
+
+
+def run_examples(
+    task_id: str,
+    solver: Solver,
+    pairs: Iterable[dict],
+    split: str,
+) -> tuple[list[ExampleFailure], list[Grid | None]]:
+    failures: list[ExampleFailure] = []
+    outputs: list[Grid | None] = []
+    for idx, pair in enumerate(pairs):
+        try:
+            raw_output = solver(copy_grid(pair["input"]))
+            output = copy_grid(raw_output)
+        except Exception as exc:  # pragma: no cover - defensive
+            reason = f"exception: {exc.__class__.__name__}: {exc}"
+            failures.append(ExampleFailure(split, idx, reason))
+            outputs.append(None)
+            continue
+        try:
+            reason = compare_grids(pair["output"], output)
+        except Exception as exc:  # pragma: no cover - defensive
+            reason = f"invalid output: {exc.__class__.__name__}: {exc}"
+        if reason:
+            failures.append(ExampleFailure(split, idx, reason))
+        outputs.append(output)
+    return failures, outputs
+
+
+def run_task(
+    task_id: str,
+    solution_path: Path,
+    data_root: Path,
+    check_train: bool,
+    check_test: bool,
+) -> TaskResult:
+    predicted: dict = {"train": [], "test": []}
+    result = TaskResult(task_id=task_id, total_examples=0, failures=[], predicted=predicted)
+    try:
+        solver = load_solver(task_id, solution_path)
+    except Exception as exc:  # pragma: no cover - defensive
+        result.load_error = f"solver load failed: {exc}"
+        return result
+
+    try:
+        task_data = load_task_json(data_root, task_id)
+    except Exception as exc:  # pragma: no cover - defensive
+        result.load_error = f"data load failed: {exc}"
+        return result
+
+    if check_train:
+        train_pairs = task_data.get("train", [])
+        result.total_examples += len(train_pairs)
+        train_failures, train_outputs = run_examples(task_id, solver, train_pairs, "train")
+        result.failures.extend(train_failures)
+        for pair, output in zip(train_pairs, train_outputs):
+            entry = {"input": pair["input"], "output": pair.get("output")}
+            if output is not None:
+                entry["actual"] = output
+            predicted["train"].append(entry)
+    else:
+        predicted["train"] = []
+    if check_test:
+        test_pairs = task_data.get("test", [])
+        result.total_examples += len(test_pairs)
+        test_failures, test_outputs = run_examples(task_id, solver, test_pairs, "test")
+        result.failures.extend(test_failures)
+        for pair, output in zip(test_pairs, test_outputs):
+            entry = {"input": pair["input"], "output": pair.get("output")}
+            if output is not None:
+                entry["actual"] = output
+            predicted["test"].append(entry)
+    else:
+        predicted["test"] = []
+    return result
+
+
+def print_task_result(result: TaskResult, quiet: bool) -> None:
+    if result.load_error:
+        print(f"{result.task_id}: FAIL ({result.load_error})")
+        return
+    if result.failures:
+        first = result.failures[0]
+        print(
+            f"{result.task_id}: FAIL ({len(result.failures)} of {result.total_examples} examples, "
+            f"first: {first.split}[{first.index + 1}] {first.reason})"
+        )
+        if not quiet:
+            for failure in result.failures[1:]:
+                print(f"    {failure.split}[{failure.index + 1}] {failure.reason}")
+    else:
+        status = "PASS" if result.total_examples else "SKIP"
+        print(f"{result.task_id}: {status} ({result.total_examples} examples)")
+
+
+def write_predictions(task_id: str, predicted: dict, out_root: Path) -> None:
+    out_root.mkdir(parents=True, exist_ok=True)
+    out_path = out_root / f"{task_id}.json"
+    with out_path.open("w", encoding="utf-8") as handle:
+        json.dump(predicted, handle, indent=2)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.skip_train and args.skip_test:
+        print("Nothing to run: both train and test splits were skipped.")
+        return 1
+
+    task_ids = set(args.tasks) if args.tasks else None
+    tasks_root = Path("tasks")
+    tasks, missing = discover_tasks(tasks_root, task_ids)
+    if missing:
+        print(f"Requested task ids not found under tasks/: {', '.join(sorted(missing))}")
+    if not tasks:
+        print("No task solutions found to run.")
+        return 1
+
+    data_root = Path(args.data_root)
+    print(f"Evaluating {len(tasks)} task(s) using data from {data_root}")
+    results: list[TaskResult] = []
+    out_root = Path("out")
+    for task_id, solution_path in tasks:
+        result = run_task(
+            task_id,
+            solution_path,
+            data_root,
+            check_train=not args.skip_train,
+            check_test=not args.skip_test,
+        )
+        if not result.load_error:
+            write_predictions(task_id, result.predicted, out_root)
+        results.append(result)
+
+    failed = [res for res in results if res.load_error or res.failures]
+    passed = [res for res in results if not res.load_error and not res.failures]
+    total_examples = sum(res.total_examples for res in results)
+    for res in results:
+        if not args.quiet or res in failed:
+            print_task_result(res, quiet=args.quiet)
+
+    print()
+    print(f"Tasks run   : {len(results)}")
+    print(f"Passed      : {len(passed)}")
+    print(f"Failed      : {len(failed)}")
+    print(f"Examples run: {total_examples}")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Also add the ability to plot with matplotlib the generated outputs next to the corresponding input and expected output.

This PR does nothing smart, it's just adding some infrastructure I wanted. Not expecting it to actually get merged, just wanted to show you something cute. The more likely outcome is that I'll reuse this basic infrastructure if/when I start playing with other solvers/my own. Cheers.

<img width="1250" height="500" alt="0934a4d8" src="https://github.com/user-attachments/assets/b885e945-6461-43af-a9be-af9bd7085c78" />

BTW: 7491f3cf blows up on the test (but not train) input

<img width="1250" height="500" alt="7491f3cf" src="https://github.com/user-attachments/assets/8661c5cf-e7d3-4e06-b958-f849c2cf6bce" />
